### PR TITLE
Adding hint for skip SSL validation option.

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ var opt struct {
 	} `cli:"create, new"`
 
 	Update struct {
-		Follow bool   `cli:"-f, --follow"`
+		Follow bool `cli:"-f, --follow"`
 	} `cli:"update"`
 
 	Delete struct{} `cli:"delete, rm"`
@@ -107,6 +107,7 @@ func options() {
 	fmt.Printf("\n")
 	fmt.Printf("  -k, --skip-ssl-validation\n")
 	fmt.Printf("                  Skip verification of the API endpoint\n")
+	fmt.Printf("                  Defaults to @W{$BLACKSMITH_SKIP_VERIFY}\n")
 	fmt.Printf("\n")
 	fmt.Printf("  -u, --username  (@Y{required}) Blacksmith username.\n")
 	fmt.Printf("                  Defaults to @W{$BLACKSMITH_USERNAME}\n")
@@ -445,7 +446,6 @@ func main() {
 			fmt.Printf("\n")
 		}
 		os.Exit(0)
-
 
 	case "delete":
 		if opt.Help {


### PR DESCRIPTION
`--skip-ssl-validation` did not show an env variable hint; went to add it; found that `BLACKSMITH_SKIP_VERIFY` already existed; realized it just wasn't shown as an option at the CLI; showing in help.

With update:
```
  -k, --skip-ssl-validation
                  Skip verification of the API endpoint
                  Defaults to $BLACKSMITH_SKIP_VERIFY
```